### PR TITLE
Proposed improvements to SimpleHttpRequestSender

### DIFF
--- a/src/Thenewboston/Common/Http/SimpleHttpRequestSender.cs
+++ b/src/Thenewboston/Common/Http/SimpleHttpRequestSender.cs
@@ -4,49 +4,76 @@ using System.Threading.Tasks;
 
 namespace Thenewboston.Common.Http
 {
-    public class SimpleHttpRequestSender : IHttpRequestSender
+    public sealed class SimpleHttpRequestSender : IHttpRequestSender
     {
-        private HttpClient _client;
+        private Uri _baseAddress; 
 
         public SimpleHttpRequestSender(string baseAddress)
         {
-            _client = new HttpClient();
-            _client.BaseAddress = new Uri(baseAddress);
+            CreateBaseAddressURI(baseAddress); 
         }
 
-        public Task<HttpResponseMessage> GetAsync(string uri)
+        private void CreateBaseAddressURI(string baseAddress)
         {
-            var response = _client.GetAsync(uri);
+            Uri uriBaseAddress;
+            Uri.TryCreate(baseAddress, UriKind.Absolute, out uriBaseAddress);
 
-            return response;
+            if(uriBaseAddress is null)
+            {
+                throw new Exception("CMN001: The base address provided to the SimpleHttpRequestSender was invalid"); 
+            }
+
+            _baseAddress = uriBaseAddress; 
         }
 
-        public Task<HttpResponseMessage> PostAsync(string uri, HttpContent content)
+        public async Task<HttpResponseMessage> GetAsync(string uri)
         {
-            var response = _client.PostAsync(uri, content);
-
-            return response;
+            using (HttpClient client = new HttpClient())
+            {
+                client.BaseAddress = _baseAddress; 
+                var response = await client.GetAsync(uri);
+                return response;
+            }
         }
 
-        public Task<HttpResponseMessage> PatchAsync(string uri, HttpContent content)
+        public async Task<HttpResponseMessage> PostAsync(string uri, HttpContent content)
         {
-            var response = _client.PatchAsync(uri, content);
-
-            return response;
+            using (HttpClient client = new HttpClient())
+            {
+                client.BaseAddress = _baseAddress;
+                var response = await client.PostAsync(uri, content);
+                return response;
+            }
         }
 
-        public Task<HttpResponseMessage> PutAsync(string uri, HttpContent content)
+        public async Task<HttpResponseMessage> PatchAsync(string uri, HttpContent content)
         {
-            var response = _client.PutAsync(uri, content);
-
-            return response;
+            using (HttpClient client = new HttpClient())
+            {
+                client.BaseAddress = _baseAddress;
+                var response = await client.PatchAsync(uri, content);
+                return response;
+            }
         }
 
-        public Task<HttpResponseMessage> DeleteAsync(string uri)
+        public async Task<HttpResponseMessage> PutAsync(string uri, HttpContent content)
         {
-            var response = _client.DeleteAsync(uri);
+            using (HttpClient client = new HttpClient())
+            {
+                client.BaseAddress = _baseAddress;
+                var response = await client.PutAsync(uri, content);
+                return response;
+            }
+        }
 
-            return response;
+        public async Task<HttpResponseMessage> DeleteAsync(string uri)
+        {
+            using (HttpClient client = new HttpClient())
+            {
+                client.BaseAddress = _baseAddress;
+                var response = await client.DeleteAsync(uri);
+                return response;
+            }
         }
     }
 }


### PR DESCRIPTION
Sooo. I tested, tested, tested and then tested again to try and get a consistent exception for timeouts, but it seemed to be difficult to catch on the SDK side. The exceptions can be different depending on usage. So this should probably be left for the client to handle. I did implement a URI parser on construction, wrapped each Http Request in a Using statement to help the HttpClients clean up after themselves, and made each method async (somewhat unnecessary, but record access is a bit easier with it in place). 

I used a live server for testing and returned the following sample results (see screenshot below). I pulled a few of the properties from a Bank's connected validators. Hopefully this will be a good stand-in for unit testing in this case. 

If we do commit this one, feel free to remove the 2000 token payment, as this did not really solve any underlying issue.

I will make a note to include the need for general timeout handling in the docs since they may want to handle them in different ways. 

![TestCapture](https://user-images.githubusercontent.com/36560776/100971812-a12b2500-3505-11eb-9166-cc727237a744.PNG)